### PR TITLE
fix: exporting types correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "preversion": "npm run lint && npm test && npm run build",
     "semantic-release": "semantic-release"
   },
-  "types": "dist/ts",
+  "types": "dist/ts/src",
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
Previously changed types to export from `dist/ts` but it changed to `dist/ts/src` now...